### PR TITLE
Make lazy param traceable when raising ConfigurationError

### DIFF
--- a/colt/builder.py
+++ b/colt/builder.py
@@ -254,7 +254,7 @@ class ColtBuilder:
 
         if origin == Lazy:
             value_cls = args[0] if args else None
-            return Lazy(config, value_cls, self)
+            return Lazy(config, param_name, value_cls, self)
 
         if isinstance(config, (list, set, tuple)):
             cls = type(config)

--- a/colt/lazy.py
+++ b/colt/lazy.py
@@ -11,6 +11,7 @@ class Lazy(Generic[T]):
     def __init__(
         self,
         config: Any,
+        param_name: str = "",
         cls: Optional[Type[T]] = None,
         builder: Optional["ColtBuilder"] = None,
     ) -> None:
@@ -18,8 +19,9 @@ class Lazy(Generic[T]):
 
         self._cls = cls
         self._config = config or {}
+        self._param_name = param_name
         self._builder = builder or ColtBuilder()
 
     def construct(self, **kwargs: Any) -> T:
         config = {**self._config, **kwargs}
-        return self._builder(config, self._cls)
+        return self._builder._build(config, self._param_name, self._cls)


### PR DESCRIPTION
Raise `ConfigurationError` with a param name when failed to construct Lazy object.