### PR TITLE
Introduce strict mode

### DIFF
--- a/colt/__init__.py
+++ b/colt/__init__.py
@@ -31,6 +31,7 @@ def build(
     *,
     typekey: Optional[str] = ...,
     argskey: Optional[str] = ...,
+    strict: bool = ...,
 ) -> T:
     ...
 
@@ -42,6 +43,7 @@ def build(
     *,
     typekey: Optional[str] = ...,
     argskey: Optional[str] = ...,
+    strict: bool = ...,
 ) -> Any:
     ...
 
@@ -52,6 +54,7 @@ def build(
     *,
     typekey: Optional[str] = None,
     argskey: Optional[str] = None,
+    strict: bool = False,
 ) -> Union[T, Any]:
-    builder = ColtBuilder(typekey, argskey)
+    builder = ColtBuilder(typekey, argskey, strict)
     return builder(config, cls)

--- a/tests/test_strict_mode.py
+++ b/tests/test_strict_mode.py
@@ -1,0 +1,42 @@
+import datetime
+from typing import Any
+
+import colt
+from colt import Registrable
+
+
+def test_strict_mode() -> None:
+    class Foo(Registrable):
+        ...
+
+    @Foo.register("bar")
+    class Bar(Foo):
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+    class Baz:
+        def __init__(self, foo: Foo, extra: Any) -> None:
+            self.foo = foo
+            self.extra = extra
+
+    config = {
+        "foo": {"@type": "bar", "name": "foo"},
+        "extra": {
+            "@type": "datetime:datetime.fromisoformat",
+            "*": ["2023-01-01T00:00:00+09:00"],
+        },
+    }
+    obj = colt.build(config, strict=True)
+    assert isinstance(obj, dict)
+    assert isinstance(obj["foo"], dict)
+    assert isinstance(obj["extra"], dict)
+
+    obj = colt.build(config, Baz, strict=True)
+    assert isinstance(obj, Baz)
+    assert isinstance(obj.foo, Bar)
+    assert isinstance(obj.extra, dict)
+
+    obj = colt.build(config, Baz, strict=False)
+    assert isinstance(obj, Baz)
+    assert isinstance(obj.foo, Bar)
+    assert isinstance(obj.extra, datetime.datetime)


### PR DESCRIPTION
If strict mode is enabled,
-  `colt` does not construct config without type hint
- `colt` does not import constructor from external modules, so only annotated types or `Registrable`s are allowed to be constructed